### PR TITLE
simple-promise-queue: typescript declaration file

### DIFF
--- a/simple-promise-queue/index.d.ts
+++ b/simple-promise-queue/index.d.ts
@@ -1,0 +1,34 @@
+// there will possibly be `awaited` keyword in Typescript 4.0
+// https://github.com/microsoft/TypeScript/pull/35998
+type Awaited<T> = T extends Promise<infer U> ? U : T;
+
+interface QueueOptions {
+  /**
+   * Defines how many "threads" (queued function calls) can be executed in parallel
+   *
+   * @default 1
+   */
+  concurrency: number;
+
+  /**
+   * Defines queue behavior
+   *
+   * false - FIFO sequence: new function calls will be added at the end of the queue
+   * true - LIFO sequence: new function calls will be prepended at the beginning of the queue
+   *
+   * @default false
+   */
+  unshift?: boolean;
+}
+
+// @todo typescript method decorators are not supported by this lib yet
+// https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/Decorators.md#method-decorators
+declare function queueable<Func extends (...args: any[]) => any>(
+  func: Func,
+  options?: QueueOptions
+): (...args: Parameters<Func>) => Promise<Awaited<ReturnType<Func>>>;
+
+export {
+  queueable as default,
+  queueable,
+};


### PR DESCRIPTION
included typings for both
```typescript
import queueable from '@ovos-media/simple-promise-queue';
```
and
```typescript
import { queueable } from '@ovos-media/simple-promise-queue';
```

Queued function args and return types are correctly inferred.

TODO (but not in this PR): typescript method decorators are not supported by this lib yet
https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/Decorators.md#method-decorators